### PR TITLE
ConvertGdiBitmap方法性能改进。

### DIFF
--- a/prjDXDrawPad.csproj
+++ b/prjDXDrawPad.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>10.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>10.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
相比于旧版本，此版本避免了一次转换所需的图像流复制，所以性能得到提升，同时还有以下潜在的好处：
- 使用更高效的可复用非托管流 `DataStream` . /
- 手动更改像素颜色信息以提供SIMD友好的代码支持。

测试通过后，可以删除所属类中的`oGdiBmpStream`字段。因为用不到了。