### PR TITLE
优化ConvertGdiBitmap方法性能

### DIFF
--- a/prjDXDrawPad.csproj
+++ b/prjDXDrawPad.csproj
@@ -23,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>10.0</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -33,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <LangVersion>10.0</LangVersion>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>

--- a/prjDXDrawPad.csproj
+++ b/prjDXDrawPad.csproj
@@ -24,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>10.0</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +36,7 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>10.0</LangVersion>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
重写了DXDrawPad.ConvertGdiBitmap方法。
相比于旧版本，此版本避免了一次转换所需的图像流复制，所以性能得到提升，同时还有以下潜在的好处：
- 使用更高效的可复用非托管流，提高性能，减少内存分配。
- 手动更改像素颜色信息以提供SIMD友好的代码支持。
- 针对不同大小的图片进行不同的ARGB转换策略，进一步提升效率。